### PR TITLE
Reset bad keys before each test.

### DIFF
--- a/src/Kaleidoscope-Model01-TestMode.cpp
+++ b/src/Kaleidoscope-Model01-TestMode.cpp
@@ -95,6 +95,9 @@ void TestMode_::testMatrix() {
   for (auto temp = 0; temp < 16; temp++) {
     KeyboardHardware.readMatrix();
   }
+  // Reset bad keys from previous tests.
+  leftBadKeys = 0;
+  rgihtBadKeys = 0;
   while (1) {
     KeyboardHardware.readMatrix();
     if (KeyboardHardware.leftHandState.all == TEST_MODE_KEY_COMBO) {


### PR DESCRIPTION
Reset the bad key bitfields each time a test is started, so that each test starts from a clean slate. Without this, it was confusing to restart the test and get an ever-increasing number of keys to appear bad immediately.