### PR TITLE
Emit an error when compiling for anything else but the Model01

### DIFF
--- a/src/Kaleidoscope-Model01-TestMode.h
+++ b/src/Kaleidoscope-Model01-TestMode.h
@@ -16,6 +16,10 @@
 
 #pragma once
 
+#ifndef ARDUINO_AVR_MODEL01
+#error The Kaleidoscope-Model01-TestMode plugin was designed for the Keyboardio Model01, and does not work with any other hardware.
+#endif
+
 #include <Arduino.h>
 #include "Kaleidoscope.h"
 


### PR DESCRIPTION
This fixes #3.